### PR TITLE
With foreign key example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,23 @@ How to setup the database:
 1. Install MySQL on your machine.
 2. Create a database "scala_sql_example".
 3. Import the SQL script (contained in "/sql/script.sql") into the new database.
+
+# Changes
+
+## Foreign keys
+
+In order to add foreign keys to table with one to many or many to many relationships, the following changes were made to the original project:
+
+* Move the TableQuery values to the component traits instead of the DAO classes
+* Add the foreign key method to the Table classes which require it
+
+To showcase their usage, the following changes were made:
+
+* Create an example query (`listInvitations` in `CoursesStudentsDAO`) which retrieves for each student the corresponding course aperos (to which he or she is invited)
+* Display the query's result through the `welcome.scala.html` view component. This requires change to:
+    * the `index.scala.html` view (to pass the parameters)
+    * the `HomeController` (to call the query and pass the parameters) 
+
+## Use lazy val
+
+Best practices is to use `lazy val` to define `TableQueries`

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import dao.{CoursesDAO, StudentsDAO}
+import dao.{CoursesDAO, CoursesStudentsDAO, StudentsDAO}
 import javax.inject._
 import models.Student
 import play.api.data._
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
  * application's home page.
  */
 @Singleton
-class HomeController @Inject()(cc: ControllerComponents, studentDAO: StudentsDAO, coursesDAO: CoursesDAO) extends AbstractController(cc) {
+class HomeController @Inject()(cc: ControllerComponents, studentDAO: StudentsDAO, coursesDAO: CoursesDAO, coursesStudentsDAO: CoursesStudentsDAO) extends AbstractController(cc) {
 
   val title = "Ultimate HEIG-VD Manager 2018"
 
@@ -58,12 +58,14 @@ class HomeController @Inject()(cc: ControllerComponents, studentDAO: StudentsDAO
   def index = Action.async { implicit request =>
     val studentsList = studentDAO.list()
     val coursesList = coursesDAO.list()
+    val studentsInvitationsMap = coursesStudentsDAO.listInvitations()
 
     // Wait for the promises to resolve, then return the list of students and courses.
     for {
       students <- studentsList
       courses <- coursesList
-    } yield Ok(views.html.index(title, students, courses))
+      studentsInvitations <- studentsInvitationsMap
+    } yield Ok(views.html.index(title, students, courses, studentsInvitations))
   }
 
   /**

--- a/app/dao/CoursesDAO.scala
+++ b/app/dao/CoursesDAO.scala
@@ -25,6 +25,8 @@ trait CoursesComponent {
     def * = (id.?, name, description, hasApero) <> (Course.tupled, Course.unapply)
   }
 
+  lazy val courses = TableQuery[CoursesTable]
+
 }
 
 // This class contains the object-oriented list of courses and offers methods to query the data.
@@ -35,11 +37,6 @@ trait CoursesComponent {
 class CoursesDAO @Inject()(protected val dbConfigProvider: DatabaseConfigProvider)(implicit executionContext: ExecutionContext)
   extends CoursesComponent with StudentsComponent with CoursesStudentsComponent with HasDatabaseConfigProvider[JdbcProfile] {
   import profile.api._
-
-  // Get the object-oriented list of courses directly from the query table.
-  val courses = TableQuery[CoursesTable]
-  val students = TableQuery[StudentsTable]
-  val coursesStudents = TableQuery[CoursesStudentsTable]
 
   /** Retrieve the list of courses sorted by name */
   def list(): Future[Seq[Course]] = {
@@ -64,7 +61,7 @@ class CoursesDAO @Inject()(protected val dbConfigProvider: DatabaseConfigProvide
   def getStudentsOfCourse(id: Long): Future[Seq[Student]] = {
     val query = for {
       courseStudent <- coursesStudents
-      student <- students if courseStudent.studentId === student.id
+      student <- courseStudent.student
     } yield student
 
     db.run(query.result)

--- a/app/dao/StudentsDAO.scala
+++ b/app/dao/StudentsDAO.scala
@@ -24,6 +24,8 @@ trait StudentsComponent {
     // Map the attributes with the model; the ID is optional.
     def * = (id.?, firstName, lastName, age, isInsolent) <> (Student.tupled, Student.unapply)
   }
+
+  lazy val students = TableQuery[StudentsTable]
 }
 
 // This class contains the object-oriented list of students and offers methods to query the data.
@@ -33,9 +35,6 @@ trait StudentsComponent {
 @Singleton
 class StudentsDAO @Inject()(protected val dbConfigProvider: DatabaseConfigProvider)(implicit executionContext: ExecutionContext) extends StudentsComponent with HasDatabaseConfigProvider[JdbcProfile] {
   import profile.api._
-
-  // Get the object-oriented list of students directly from the query table.
-  val students = TableQuery[StudentsTable]
 
   /** Retrieve the list of students */
   def list(): Future[Seq[Student]] = {

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -2,7 +2,7 @@
  * This template takes a single argument, a String containing a
  * message to display.
  *@
-@(message: String, students: Seq[Student], courses: Seq[Course])
+@(message: String, students: Seq[Student], courses: Seq[Course], studentsInvitations: Map[Student, Seq[Course]])
 
 @*
  * Call the `main` template with two arguments. The first
@@ -15,6 +15,6 @@
      * Get an `Html` object by calling the built-in Play welcome
      * template and passing a `String` message.
      *@
-    @welcome(message, students, courses)
+    @welcome(message, students, courses, studentsInvitations)
 
 }

--- a/app/views/welcome.scala.html
+++ b/app/views/welcome.scala.html
@@ -1,4 +1,4 @@
-@(message: String, students: Seq[Student], courses: Seq[Course])
+@(message: String, students: Seq[Student], courses: Seq[Course], studentsInvitations: Map[Student, Seq[Course]])
 
   @defining(play.core.PlayVersion.current) { version =>
       <h1>Students</h1>
@@ -50,6 +50,21 @@
           </tr>
         }
       </table>
+
+<h1>Who's going to which apero ?</h1>
+<p>Insolent student are not invited to their courses' apero.</p>
+<table class="things-table" id="table-courses-student">
+    <tr>
+        <th>Student</th>
+        <th>Apero(s)</th>
+    </tr>
+    @for((student, courses) <- studentsInvitations) {
+    <tr>
+        <td>@student.firstName @student.lastName</td>
+        <td>@courses.map(_.name).mkString(", ")</td>
+    </tr>
+    }
+</table>
 
       Add your <strong>OWN</strong> student!
       <!-- You may need to compile the application so the IDE will recognize the "postStudent" route. -->


### PR DESCRIPTION
## Foreign keys

In order to add foreign keys to table with one to many or many to many relationships, the following changes were made to the original project:

* Move the TableQuery values to the component traits instead of the DAO classes
* Add the foreign key method to the Table classes which require it

To showcase their usage, the following changes were made:

* Create an example query (`listInvitations` in `CoursesStudentsDAO`) which retrieves for each student the corresponding course aperos (to which he or she is invited)
* Display the query's result through the `welcome.scala.html` view component. This requires change to:
    * the `index.scala.html` view (to pass the parameters)
    * the `HomeController` (to call the query and pass the parameters) 

## Use lazy val

Best practices is to use `lazy val` to define `TableQueries`